### PR TITLE
Handle Content-Type header not being sent

### DIFF
--- a/validator.rb
+++ b/validator.rb
@@ -33,8 +33,8 @@ def download_feed(jsonfeed_url, limit = 5)
 
     if response.is_a?(Net::HTTPSuccess)
       s = response.body
-      if !response["content-type"].include?("application/json")
-        raise FeedError.new("error", "Content-Type was #{response['content-type']}. It should be application/json.")
+      if !response["content-type"] || !response["content-type"].include?("application/json")
+        raise FeedError.new("error", "Content-Type was #{response['content-type'] || "not sent"}. It should be application/json.")
       end
     elsif response.is_a?(Net::HTTPRedirection)
       location = response["location"]


### PR DESCRIPTION
Fixes #1.

If we upgrade to Ruby 2.3.0 we could use the [safe navigation operator](http://mitrev.net/ruby/2015/11/13/the-operator-in-ruby/) (`&.`).