### PR TITLE
Set `feed_url` to be uri in schema

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -209,6 +209,7 @@
     },
     "feed_url": {
       "description": "The URL of the feed, and serves as the unique identifier for the feed. As with 'home_page_url', this should be considered required for feeds on the public web."
+      "allOf": [ { "$ref": "#/definitions/uri" } ]
     },
     "home_page_url": {
       "description": "The URL of the resource that the feed describes. This resource may or may not actually be a “home” page, but it should be an HTML page. If a feed is published on the public web, this should be considered as required. But it may not make sense in the case of a file created on a desktop computer, when that file is not shared or is shared only privately.",


### PR DESCRIPTION
`feed_url` not being marked as an uri is an oversight, right?